### PR TITLE
fix: clarify usergroup name/handle conflict error message

### DIFF
--- a/slack/resource_usergroup.go
+++ b/slack/resource_usergroup.go
@@ -86,9 +86,10 @@ func resourceSlackUserGroupCreate(ctx context.Context, d *schema.ResourceData, m
 		if err.Error() != "name_already_exists" && err.Error() != "handle_already_exists" {
 			return diag.Errorf("could not create usergroup %s: %v", name, err)
 		}
+		conflict := err.Error()
 		group, err := findUserGroupByName(ctx, name, true, team_id, m)
 		if err != nil {
-			return diag.Errorf("could not find usergroup %s: %v", name, err)
+			return diag.Errorf("usergroup %q already exists in the Slack workspace (Slack API returned %q), but the provider could not find the existing usergroup to import it into the Terraform state: %v. This usually happens when the existing usergroup belongs to a different team_id than the one configured (team_id=%q) or its name/handle does not match exactly. Set the correct team_id, or import the existing usergroup with 'terraform import'.", name, conflict, err, team_id)
 		}
 		_, err = client.EnableUserGroupContext(ctx, group.ID, slack.DisableUserGroupOptionTeamID(team_id))
 		if err != nil {

--- a/slack/resource_usergroup_create_test.go
+++ b/slack/resource_usergroup_create_test.go
@@ -44,7 +44,7 @@ func TestResourceSlackUserGroupCreate_NameConflictNotFound(t *testing.T) {
 	})
 
 	d := schema.TestResourceDataRaw(t, resourceSlackUserGroup().Schema, map[string]interface{}{
-		"name": "Lending Bolivia",
+		"name": "Example Group",
 	})
 
 	diags := resourceSlackUserGroupCreate(context.Background(), d, client)
@@ -55,7 +55,7 @@ func TestResourceSlackUserGroupCreate_NameConflictNotFound(t *testing.T) {
 
 	summary := diags[0].Summary
 	for _, want := range []string{
-		`usergroup "Lending Bolivia" already exists in the Slack workspace`,
+		`usergroup "Example Group" already exists in the Slack workspace`,
 		"name_already_exists",
 		"terraform import",
 	} {
@@ -79,8 +79,8 @@ func TestResourceSlackUserGroupCreate_HandleConflictNotFound(t *testing.T) {
 	})
 
 	d := schema.TestResourceDataRaw(t, resourceSlackUserGroup().Schema, map[string]interface{}{
-		"name":   "Lending Bolivia",
-		"handle": "lending-bolivia",
+		"name":   "Example Group",
+		"handle": "example-group",
 	})
 
 	diags := resourceSlackUserGroupCreate(context.Background(), d, client)
@@ -107,7 +107,7 @@ func TestResourceSlackUserGroupCreate_OtherErrorKeepsGenericMessage(t *testing.T
 	})
 
 	d := schema.TestResourceDataRaw(t, resourceSlackUserGroup().Schema, map[string]interface{}{
-		"name": "Lending Bolivia",
+		"name": "Example Group",
 	})
 
 	diags := resourceSlackUserGroupCreate(context.Background(), d, client)
@@ -117,7 +117,7 @@ func TestResourceSlackUserGroupCreate_OtherErrorKeepsGenericMessage(t *testing.T
 	}
 
 	summary := diags[0].Summary
-	if !strings.Contains(summary, "could not create usergroup Lending Bolivia") {
+	if !strings.Contains(summary, "could not create usergroup Example Group") {
 		t.Errorf("expected the generic create error, got: %s", summary)
 	}
 	if strings.Contains(summary, "already exists in the Slack workspace") {
@@ -129,7 +129,7 @@ func TestResourceSlackUserGroupCreate_OtherErrorKeepsGenericMessage(t *testing.T
 // happy recovery path: when the name already exists and the provider can locate
 // the existing usergroup, it adopts it into state without error.
 func TestResourceSlackUserGroupCreate_NameConflictAdoptsExisting(t *testing.T) {
-	group := `{"id":"S123","team_id":"","name":"Lending Bolivia","handle":"lending-bolivia","description":"desc","prefs":{"channels":[],"groups":[]},"users":[]}`
+	group := `{"id":"S123","team_id":"","name":"Example Group","handle":"example-group","description":"desc","prefs":{"channels":[],"groups":[]},"users":[]}`
 	client := newMockSlackAPIServer(t, map[string]string{
 		"usergroups.create": `{"ok":false,"error":"name_already_exists"}`,
 		"usergroups.list":   `{"ok":true,"usergroups":[` + group + `]}`,
@@ -138,7 +138,7 @@ func TestResourceSlackUserGroupCreate_NameConflictAdoptsExisting(t *testing.T) {
 	})
 
 	d := schema.TestResourceDataRaw(t, resourceSlackUserGroup().Schema, map[string]interface{}{
-		"name": "Lending Bolivia",
+		"name": "Example Group",
 	})
 
 	diags := resourceSlackUserGroupCreate(context.Background(), d, client)

--- a/slack/resource_usergroup_create_test.go
+++ b/slack/resource_usergroup_create_test.go
@@ -1,0 +1,152 @@
+package slack
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/lfventura/slack-go"
+)
+
+// newMockSlackAPIServer spins up an httptest server that returns the provided
+// JSON body for each Slack API method path (e.g. "usergroups.create"). It lets
+// us unit test the create flow without talking to the real Slack API.
+func newMockSlackAPIServer(t *testing.T, responses map[string]string) *slack.Client {
+	t.Helper()
+
+	mux := http.NewServeMux()
+	for path, body := range responses {
+		body := body
+		mux.HandleFunc("/"+path, func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(body))
+		})
+	}
+
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+
+	return slack.New("test-token", slack.OptionAPIURL(server.URL+"/"))
+}
+
+// TestResourceSlackUserGroupCreate_NameConflictNotFound reproduces the scenario
+// where the usergroup name already exists in the workspace (Slack returns
+// name_already_exists on create) but the provider cannot locate the existing
+// usergroup to adopt it. The resulting error must clearly explain the conflict
+// instead of the misleading "could not find usergroup" message.
+func TestResourceSlackUserGroupCreate_NameConflictNotFound(t *testing.T) {
+	client := newMockSlackAPIServer(t, map[string]string{
+		"usergroups.create": `{"ok":false,"error":"name_already_exists"}`,
+		"usergroups.list":   `{"ok":true,"usergroups":[]}`,
+	})
+
+	d := schema.TestResourceDataRaw(t, resourceSlackUserGroup().Schema, map[string]interface{}{
+		"name": "Lending Bolivia",
+	})
+
+	diags := resourceSlackUserGroupCreate(context.Background(), d, client)
+
+	if !diags.HasError() {
+		t.Fatalf("expected an error diagnostic, got none")
+	}
+
+	summary := diags[0].Summary
+	for _, want := range []string{
+		`usergroup "Lending Bolivia" already exists in the Slack workspace`,
+		"name_already_exists",
+		"terraform import",
+	} {
+		if !strings.Contains(summary, want) {
+			t.Errorf("expected error message to contain %q, got: %s", want, summary)
+		}
+	}
+
+	if strings.HasPrefix(summary, "could not find usergroup") {
+		t.Errorf("error message should not use the misleading 'could not find usergroup' prefix, got: %s", summary)
+	}
+}
+
+// TestResourceSlackUserGroupCreate_HandleConflictNotFound covers the same
+// recovery path but triggered by a handle_already_exists conflict, ensuring the
+// conflict reason is surfaced in the message.
+func TestResourceSlackUserGroupCreate_HandleConflictNotFound(t *testing.T) {
+	client := newMockSlackAPIServer(t, map[string]string{
+		"usergroups.create": `{"ok":false,"error":"handle_already_exists"}`,
+		"usergroups.list":   `{"ok":true,"usergroups":[]}`,
+	})
+
+	d := schema.TestResourceDataRaw(t, resourceSlackUserGroup().Schema, map[string]interface{}{
+		"name":   "Lending Bolivia",
+		"handle": "lending-bolivia",
+	})
+
+	diags := resourceSlackUserGroupCreate(context.Background(), d, client)
+
+	if !diags.HasError() {
+		t.Fatalf("expected an error diagnostic, got none")
+	}
+
+	summary := diags[0].Summary
+	if !strings.Contains(summary, "handle_already_exists") {
+		t.Errorf("expected error message to surface the handle_already_exists conflict, got: %s", summary)
+	}
+	if !strings.Contains(summary, "already exists in the Slack workspace") {
+		t.Errorf("expected the conflict message, got: %s", summary)
+	}
+}
+
+// TestResourceSlackUserGroupCreate_OtherErrorKeepsGenericMessage ensures a
+// non-conflict create failure still returns the generic create error and does
+// not use the new conflict wording.
+func TestResourceSlackUserGroupCreate_OtherErrorKeepsGenericMessage(t *testing.T) {
+	client := newMockSlackAPIServer(t, map[string]string{
+		"usergroups.create": `{"ok":false,"error":"invalid_auth"}`,
+	})
+
+	d := schema.TestResourceDataRaw(t, resourceSlackUserGroup().Schema, map[string]interface{}{
+		"name": "Lending Bolivia",
+	})
+
+	diags := resourceSlackUserGroupCreate(context.Background(), d, client)
+
+	if !diags.HasError() {
+		t.Fatalf("expected an error diagnostic, got none")
+	}
+
+	summary := diags[0].Summary
+	if !strings.Contains(summary, "could not create usergroup Lending Bolivia") {
+		t.Errorf("expected the generic create error, got: %s", summary)
+	}
+	if strings.Contains(summary, "already exists in the Slack workspace") {
+		t.Errorf("did not expect the conflict message for a non-conflict error, got: %s", summary)
+	}
+}
+
+// TestResourceSlackUserGroupCreate_NameConflictAdoptsExisting verifies the
+// happy recovery path: when the name already exists and the provider can locate
+// the existing usergroup, it adopts it into state without error.
+func TestResourceSlackUserGroupCreate_NameConflictAdoptsExisting(t *testing.T) {
+	group := `{"id":"S123","team_id":"","name":"Lending Bolivia","handle":"lending-bolivia","description":"desc","prefs":{"channels":[],"groups":[]},"users":[]}`
+	client := newMockSlackAPIServer(t, map[string]string{
+		"usergroups.create": `{"ok":false,"error":"name_already_exists"}`,
+		"usergroups.list":   `{"ok":true,"usergroups":[` + group + `]}`,
+		"usergroups.enable": `{"ok":true,"usergroup":` + group + `}`,
+		"usergroups.update": `{"ok":true,"usergroup":` + group + `}`,
+	})
+
+	d := schema.TestResourceDataRaw(t, resourceSlackUserGroup().Schema, map[string]interface{}{
+		"name": "Lending Bolivia",
+	})
+
+	diags := resourceSlackUserGroupCreate(context.Background(), d, client)
+
+	if diags.HasError() {
+		t.Fatalf("expected no error, got: %v", diags)
+	}
+	if d.Id() != "S123" {
+		t.Errorf("expected the existing usergroup to be adopted as S123, got: %q", d.Id())
+	}
+}


### PR DESCRIPTION
## Problem

When applying a `slack_usergroup` resource whose name already exists in the workspace, the provider fails with a misleading error:

```
Error: could not find usergroup Example Group: could not find usergroup Example Group
```

This suggests the usergroup does **not** exist, when in fact it does. What actually happens is:

1. `CreateUserGroup` returns `name_already_exists` (or `handle_already_exists`).
2. The provider tries to adopt the existing usergroup via `findUserGroupByName`.
3. That lookup fails (commonly because the existing usergroup belongs to a different `team_id`, or the name/handle does not match exactly), producing the confusing "could not find usergroup" message.

## Change

Surface the real situation instead. When the create conflict cannot be reconciled, the error now:

- states that the usergroup already exists in the Slack workspace;
- includes the Slack conflict reason (`name_already_exists` / `handle_already_exists`);
- includes the configured `team_id`;
- points the user to set the correct `team_id` or import the existing usergroup with `terraform import`.

New message:

```
usergroup "Example Group" already exists in the Slack workspace (Slack API returned "name_already_exists"),
but the provider could not find the existing usergroup to import it into the Terraform state: could not find
usergroup Example Group. This usually happens when the existing usergroup belongs to a different team_id than
the one configured (team_id="") or its name/handle does not match exactly. Set the correct team_id, or import
the existing usergroup with 'terraform import'.
```

The internal `findUserGroupByName` / `findUserGroupByID` messages (used by the data source and covered by existing tests) are left unchanged.

## Tests

Added httptest-based unit tests in `slack/resource_usergroup_create_test.go` that run without Slack credentials (so they execute under both `make test` and `make testacc`):

- `NameConflictNotFound` — asserts the clarified error message.
- `HandleConflictNotFound` — asserts the handle conflict reason is surfaced.
- `OtherErrorKeepsGenericMessage` — a non-conflict create error keeps the generic message.
- `NameConflictAdoptsExisting` — the happy path still adopts the existing usergroup into state.

Validated with `go build ./...`, `go vet ./slack/`, and the new unit tests + `TestProvider` passing.
