### PR TITLE
fix: convert conversation between public and private on is_private change

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,57 +1,116 @@
 # Terraform Provider for Slack
 
+[![Release](https://img.shields.io/github/v/release/lfventura/terraform-provider-slack)](https://github.com/lfventura/terraform-provider-slack/releases)
+[![Registry](https://img.shields.io/badge/terraform-registry-623CE4)](https://registry.terraform.io/providers/lfventura/slack/latest)
+[![Build](https://github.com/lfventura/terraform-provider-slack/actions/workflows/build.yml/badge.svg)](https://github.com/lfventura/terraform-provider-slack/actions/workflows/build.yml)
+[![CodeQL](https://github.com/lfventura/terraform-provider-slack/actions/workflows/codeql-analysis.yml/badge.svg)](https://github.com/lfventura/terraform-provider-slack/actions/workflows/codeql-analysis.yml)
 
-### This is a Fork!!!
+Manage Slack conversations, user groups and memberships with Terraform.
 
-Feel free to use :) It is available at Terraform Registry - https://registry.terraform.io/providers/lfventura/slack/latest
+Fork of [pablovarela/terraform-provider-slack](https://github.com/pablovarela/terraform-provider-slack) with first-class support for **Slack Enterprise Grid** (`team_id` on conversations and user groups) and additional fixes. Since v2.0.0 it depends on the upstream [slack-go/slack](https://github.com/slack-go/slack) library.
 
-Some notes about this fork...
+## Usage
 
-- It previously used a fork of the slack-go library (https://github.com/lfventura/slack-go) to allow creating usergroups in Slack Enterprise Grid accounts (team_id support, proposed upstream in https://github.com/slack-go/slack/pull/1179). The official library now ships this functionality, so since v2.0.0 this provider depends on the upstream https://github.com/slack-go/slack directly.
-- This provider as been created based on https://github.com/pablovarela/terraform-provider-slack v1.2.2 just adding support for Team ID to create conversations and usergroups.
-- A bug fix in the data conversations where it was not finding Archieved channels, with this bug the resource conversation was unable to reactivate a channel that was deleted, now it is working :)
+```hcl
+terraform {
+  required_providers {
+    slack = {
+      source  = "lfventura/slack"
+      version = "~> 2.0"
+    }
+  }
+}
 
+provider "slack" {
+  token = var.slack_token # or set SLACK_TOKEN
+}
 
-### Some notes for reference...
+data "slack_user" "someone" {
+  name = "some.user"
+}
 
-If you want to locally prove the provider without running any scripts...
+resource "slack_usergroup" "team" {
+  name        = "My Team"
+  handle      = "my-team"
+  description = "Managed by Terraform"
+  users       = [data.slack_user.someone.id]
+}
 
-```shell
-go build -ldflags="-X main.version=0.0.1 -X main.commit=n/a"
-mv terraform-provider-slack ~/.terraform.d/plugins/terraform.local/local/slack/0.0.1/darwin_arm64/terraform-provider-slack_v0.0.1
+resource "slack_conversation" "channel" {
+  name              = "my-channel"
+  topic             = "Managed by Terraform"
+  permanent_members = slack_usergroup.team.users
+  is_private        = true
+}
 ```
 
-and in your providers.tf
+Full documentation on the [Terraform Registry](https://registry.terraform.io/providers/lfventura/slack/latest/docs).
+
+## Resources and data sources
+
+| Type | Name | Description |
+|---|---|---|
+| Resource | `slack_conversation` | Channels: create, archive, rename, topic/purpose, members, public/private |
+| Resource | `slack_usergroup` | User groups: create, members, handle, channels |
+| Data source | `slack_conversation` | Look up a channel by ID or name |
+| Data source | `slack_user` | Look up a user by name or email |
+| Data source | `slack_users` | List all workspace users |
+| Data source | `slack_usergroup` | Look up a user group by ID or name |
+
+## Authentication
+
+Create a [Slack App](https://api.slack.com/apps), install it to your workspace and use its token via the `token` argument or the `SLACK_TOKEN` environment variable.
+
+Required scopes:
+
+- `channels:read`, `channels:write`, `groups:read`, `groups:write`
+- `usergroups:read`, `usergroups:write`
+- `users:read`, `users:read.email`
+
+## Enterprise Grid
+
+- `team_id` is supported on `slack_conversation`, `slack_usergroup` and the data sources, so you can target a specific workspace within an org.
+- Changing `is_private` on an existing channel converts it in place through the [Admin API](https://api.slack.com/methods/admin.conversations.convertToPrivate). This requires a user token (`xoxp`) with the `admin.conversations:write` scope. Outside Enterprise Grid, recreate the channel instead (`terraform apply -replace`).
+
+## Development
+
+Requirements: [Go](https://go.dev/) (see `go.mod` for the minimum version).
 
 ```shell
+go build ./...        # compile
+go test ./...         # unit tests (acceptance tests skip without TF_ACC)
+golangci-lint run     # lint
+```
+
+Acceptance tests run against a real workspace and create/destroy resources. Use a dedicated test workspace:
+
+```shell
+SLACK_TOKEN=xoxp-... TF_ACC=1 go test ./... -v
+```
+
+To try a local build with Terraform:
+
+```shell
+go build -ldflags="-X main.version=0.0.1 -X main.commit=n/a" -o terraform-provider-slack_v0.0.1
+mkdir -p ~/.terraform.d/plugins/terraform.local/local/slack/0.0.1/$(go env GOOS)_$(go env GOARCH)
+mv terraform-provider-slack_v0.0.1 ~/.terraform.d/plugins/terraform.local/local/slack/0.0.1/$(go env GOOS)_$(go env GOARCH)/
+```
+
+```hcl
+terraform {
+  required_providers {
     slack = {
-      source = "terraform.local/local/slack"
+      source  = "terraform.local/local/slack"
       version = "0.0.1"
     }
+  }
+}
 ```
 
+## Releasing
 
-### How to release
+Push a `v*` tag. The [Release workflow](.github/workflows/release.yml) builds, signs and publishes the release with GoReleaser, and the Terraform Registry picks it up automatically.
 
-1. Push a new `v*` tag to GitHub — the `Release` workflow (GoReleaser) builds, signs and publishes the release automatically.
+## Credits
 
-
-### ToDo
-Update Tests - PRs are welcome :D
-
----
-
-### Original repo README
-
-[![Go Report Card](https://goreportcard.com/badge/github.com/pablovarela/terraform-provider-slack)](https://goreportcard.com/report/github.com/pablovarela/terraform-provider-slack) <a href="https://github.com/pablovarela/terraform-provider-slack/actions?query=workflow%3ABuild">![build](https://github.com/pablovarela/terraform-provider-slack/workflows/Build/badge.svg)</a> <a href="https://github.com/pablovarela/terraform-provider-slack/actions?query=workflow%3Arelease">![release](https://github.com/pablovarela/terraform-provider-slack/workflows/release/badge.svg)</a>
-
-The Terraform Provider for Slack is a plugin for Terraform that allows the
-management of Slack resources.
-
-### Quick Start
-
-- [Using the provider ](https://registry.terraform.io/providers/pablovarela/slack/latest/docs)
-
-### Documentation
-
-Full, comprehensive documentation is available on the Terraform Registry: https://registry.terraform.io/providers/pablovarela/slack/latest/docs
+Based on [pablovarela/terraform-provider-slack](https://github.com/pablovarela/terraform-provider-slack). Licensed under the [Apache License 2.0](LICENSE).

--- a/docs/resources/conversation.md
+++ b/docs/resources/conversation.md
@@ -88,6 +88,11 @@ The following arguments are supported:
 - `purpose` - (Optional) purpose of the channel.
 - `permanent_members` - (Optional) user IDs to add to the channel.
 - `is_private` - (Optional) create a private channel instead of a public one.
+Changing this on an existing channel converts it between public and private
+using the [Slack Admin API](https://api.slack.com/methods/admin.conversations.convertToPrivate),
+which is only available on Enterprise Grid organizations and requires a user
+token (`xoxp`) with the `admin.conversations:write` scope. Outside Enterprise
+Grid, recreate the channel instead (e.g. `terraform apply -replace`).
 - `is_archived` - (Optional) indicates a conversation is archived. Frozen in time.
 - `action_on_destroy` - (Optional, Default `archive`) indicates whether the
 conversation should be archived or left behind on destroy. Valid values are

--- a/slack/resource_conversation.go
+++ b/slack/resource_conversation.go
@@ -407,6 +407,12 @@ func resourceSlackConversationUpdate(ctx context.Context, d *schema.ResourceData
 		}
 	}
 
+	if d.HasChange("is_private") {
+		if err := convertConversationPrivacy(ctx, client, id, d.Get("is_private").(bool)); err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
 	if d.HasChange("permanent_members") {
 		err := updateChannelMembers(ctx, d, client, id)
 		if err != nil {
@@ -415,6 +421,38 @@ func resourceSlackConversationUpdate(ctx context.Context, d *schema.ResourceData
 	}
 
 	return resourceSlackConversationRead(ctx, d, m)
+}
+
+// convertConversationPrivacy converts a channel between public and private
+// using the Slack Admin API (admin.conversations.convertToPrivate/Public).
+// These methods are only available on Enterprise Grid organizations and
+// require a user token (xoxp) with the admin.conversations:write scope.
+func convertConversationPrivacy(ctx context.Context, client *slack.Client, id string, isPrivate bool) error {
+	var direction string
+	var err error
+	if isPrivate {
+		direction = "public to private"
+		err = client.AdminConversationsConvertToPrivate(ctx, id)
+	} else {
+		direction = "private to public"
+		err = client.AdminConversationsConvertToPublic(ctx, id)
+	}
+	if err != nil {
+		switch err.Error() {
+		case "not_an_admin", "not_allowed_token_type", "missing_scope", "feature_not_enabled", "not_an_enterprise":
+			return fmt.Errorf("couldn't convert conversation %s from %s: %s. "+
+				"Converting a channel requires the Slack Admin API, which is only available on Enterprise Grid "+
+				"organizations using a user token (xoxp) with the admin.conversations:write scope. "+
+				"If you cannot use the Admin API, recreate the channel instead (e.g. 'terraform taint' / '-replace')", id, direction, err)
+		case "restricted_action", "could_not_convert_channel", "external_channel_error":
+			return fmt.Errorf("couldn't convert conversation %s from %s: %s. "+
+				"Check the Slack admin settings and the channel type restrictions "+
+				"(see https://api.slack.com/methods/admin.conversations.convertToPrivate)", id, direction, err)
+		default:
+			return fmt.Errorf("couldn't convert conversation %s from %s: %s", id, direction, err)
+		}
+	}
+	return nil
 }
 
 func resourceSlackConversationDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {

--- a/slack/resource_conversation_update_test.go
+++ b/slack/resource_conversation_update_test.go
@@ -1,0 +1,80 @@
+package slack
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+// TestConvertConversationPrivacy_ToPrivate verifies that flipping is_private
+// to true calls admin.conversations.convertToPrivate (issue #3: changing
+// is_private used to be silently ignored by the update flow).
+func TestConvertConversationPrivacy_ToPrivate(t *testing.T) {
+	client := newMockSlackAPIServer(t, map[string]string{
+		"admin.conversations.convertToPrivate": `{"ok":true}`,
+	})
+
+	if err := convertConversationPrivacy(context.Background(), client, "C123", true); err != nil {
+		t.Fatalf("expected no error, got: %s", err)
+	}
+}
+
+// TestConvertConversationPrivacy_ToPublic verifies the private -> public
+// direction calls admin.conversations.convertToPublic.
+func TestConvertConversationPrivacy_ToPublic(t *testing.T) {
+	client := newMockSlackAPIServer(t, map[string]string{
+		"admin.conversations.convertToPublic": `{"ok":true}`,
+	})
+
+	if err := convertConversationPrivacy(context.Background(), client, "C123", false); err != nil {
+		t.Fatalf("expected no error, got: %s", err)
+	}
+}
+
+// TestConvertConversationPrivacy_NotAdmin ensures a clear, actionable error is
+// returned when the token cannot use the Admin API (non Enterprise Grid or
+// missing admin.conversations:write scope).
+func TestConvertConversationPrivacy_NotAdmin(t *testing.T) {
+	client := newMockSlackAPIServer(t, map[string]string{
+		"admin.conversations.convertToPrivate": `{"ok":false,"error":"not_an_admin"}`,
+	})
+
+	err := convertConversationPrivacy(context.Background(), client, "C123", true)
+	if err == nil {
+		t.Fatalf("expected an error, got none")
+	}
+
+	for _, want := range []string{
+		"not_an_admin",
+		"Enterprise Grid",
+		"admin.conversations:write",
+		"public to private",
+	} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("expected error message to contain %q, got: %s", want, err)
+		}
+	}
+}
+
+// TestConvertConversationPrivacy_RestrictedAction covers admin-side policy
+// restrictions surfacing a pointer to the Slack admin settings.
+func TestConvertConversationPrivacy_RestrictedAction(t *testing.T) {
+	client := newMockSlackAPIServer(t, map[string]string{
+		"admin.conversations.convertToPublic": `{"ok":false,"error":"restricted_action"}`,
+	})
+
+	err := convertConversationPrivacy(context.Background(), client, "C123", false)
+	if err == nil {
+		t.Fatalf("expected an error, got none")
+	}
+
+	for _, want := range []string{
+		"restricted_action",
+		"private to public",
+		"admin settings",
+	} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("expected error message to contain %q, got: %s", want, err)
+		}
+	}
+}


### PR DESCRIPTION
Fixes #3

## Problem
Changing `is_private` on an existing `slack_conversation` was silently ignored. The schema marks it `Optional` without `ForceNew`, but `resourceSlackConversationUpdate` had no `d.HasChange("is_private")` branch — the apply 'succeeded' doing nothing, the Read refreshed the real value from the API, and the diff came back on every subsequent plan, forever.

## Fix
The update flow now converts the channel via the **Slack Admin API**:
- `is_private = true` → `admin.conversations.convertToPrivate`
- `is_private = false` → `admin.conversations.convertToPublic`

These methods only work on **Enterprise Grid** orgs with a **user token (xoxp)** carrying the `admin.conversations:write` scope. When the token can't use them (`not_an_admin`, `missing_scope`, `not_an_enterprise`, ...), the provider returns a clear error explaining the requirements and suggesting `terraform apply -replace` as the fallback for non-Grid workspaces. Policy-side failures (`restricted_action`, `could_not_convert_channel`) point at the Slack admin settings.

## Tests
- 4 new unit tests using the existing mock Slack API server: both conversion directions plus the two error classes (`not_an_admin`, `restricted_action`), asserting actionable messages.
- `go build`, `go vet`, `golangci-lint run` (0 issues), full `go test ./...` green.

Docs for `is_private` updated with the conversion behavior and its requirements.