### PR TITLE
fix: mark token sensitive, validate token format, make remove() non-mutating

### DIFF
--- a/slack/provider.go
+++ b/slack/provider.go
@@ -2,6 +2,8 @@ package slack
 
 import (
 	"context"
+	"fmt"
+	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -15,6 +17,7 @@ func Provider() *schema.Provider {
 			"token": {
 				Type:        schema.TypeString,
 				Required:    true,
+				Sensitive:   true,
 				DefaultFunc: schema.EnvDefaultFunc("SLACK_TOKEN", nil),
 				Description: "The Slack token",
 			},
@@ -43,8 +46,35 @@ func providerConfigure(_ context.Context, d *schema.ResourceData) (interface{}, 
 	if !ok {
 		return nil, diag.Errorf("could not create slack client. Please provide a token.")
 	}
-	slackClient := slack.New(token.(string))
+
+	tokenStr := token.(string)
+	if err := validateSlackToken(tokenStr); err != nil {
+		return nil, diag.FromErr(err)
+	}
+
+	slackClient := slack.New(tokenStr)
 	return slackClient, diags
+}
+
+// validateSlackToken fails fast on tokens that cannot be valid, instead of
+// letting every API call fail later with invalid_auth.
+func validateSlackToken(token string) error {
+	if token == "" {
+		return fmt.Errorf("token cannot be empty")
+	}
+
+	// Slack token prefixes:
+	// xoxb- bot tokens, xoxp- user tokens, xoxa- app-level (legacy),
+	// xoxe- Enterprise Grid, xoxr- refresh tokens, xapp- app tokens.
+	validPrefixes := []string{"xoxb-", "xoxp-", "xoxa-", "xoxe-", "xoxr-", "xapp-"}
+
+	for _, prefix := range validPrefixes {
+		if strings.HasPrefix(token, prefix) {
+			return nil
+		}
+	}
+
+	return fmt.Errorf("invalid token format: Slack tokens must start with one of: %s", strings.Join(validPrefixes, ", "))
 }
 
 func schemaSetToSlice(set *schema.Set) []string {
@@ -55,11 +85,14 @@ func schemaSetToSlice(set *schema.Set) []string {
 	return s
 }
 
+// remove returns a copy of s without r, leaving the input slice untouched
+// (the previous in-place implementation mutated the caller's backing array).
 func remove(s []string, r string) []string {
-	for i, v := range s {
-		if v == r {
-			return append(s[:i], s[i+1:]...)
+	result := make([]string, 0, len(s))
+	for _, v := range s {
+		if v != r {
+			result = append(result, v)
 		}
 	}
-	return s
+	return result
 }

--- a/slack/provider_config_test.go
+++ b/slack/provider_config_test.go
@@ -1,0 +1,61 @@
+package slack
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestValidateSlackToken(t *testing.T) {
+	valid := []string{
+		"xoxb-1234-abcd",
+		"xoxp-1234-abcd",
+		"xoxa-1234-abcd",
+		"xoxe-1234-abcd",
+		"xoxr-1234-abcd",
+		"xapp-1-A1-abcd",
+	}
+	for _, token := range valid {
+		if err := validateSlackToken(token); err != nil {
+			t.Errorf("expected token %q to be valid, got: %s", token, err)
+		}
+	}
+
+	invalid := []string{
+		"",
+		"not-a-token",
+		"xox-1234",
+		"Bearer xoxb-1234",
+	}
+	for _, token := range invalid {
+		err := validateSlackToken(token)
+		if err == nil {
+			t.Errorf("expected token %q to be rejected", token)
+			continue
+		}
+		if token != "" && !strings.Contains(err.Error(), "xoxb-") {
+			t.Errorf("expected error for %q to list valid prefixes, got: %s", token, err)
+		}
+	}
+}
+
+// TestRemove_DoesNotMutateInput guards against the previous in-place
+// implementation, which reordered/overwrote the caller's backing array.
+func TestRemove_DoesNotMutateInput(t *testing.T) {
+	input := []string{"a", "b", "c"}
+
+	got := remove(input, "b")
+
+	if len(got) != 2 || got[0] != "a" || got[1] != "c" {
+		t.Errorf("expected [a c], got: %v", got)
+	}
+	if input[0] != "a" || input[1] != "b" || input[2] != "c" {
+		t.Errorf("input slice was mutated: %v", input)
+	}
+
+	if got := remove(input, "missing"); len(got) != 3 {
+		t.Errorf("expected all 3 elements when removing a missing value, got: %v", got)
+	}
+	if got := remove([]string{"x", "x", "y"}, "x"); len(got) != 1 || got[0] != "y" {
+		t.Errorf("expected all occurrences removed, got: %v", got)
+	}
+}


### PR DESCRIPTION
Ports the applicable (pre-framework-migration) hardening from zenchef/terraform-provider-slack@36dab608:

- **`token` is now `Sensitive`** — redacted from logs and plan/console output.
- **Fail-fast token validation** — rejects tokens that don't start with a known Slack prefix (`xoxb-`, `xoxp-`, `xoxa-`, `xoxe-`, `xoxr-`, `xapp-`) at provider configure time, instead of every API call failing later with `invalid_auth`.
- **`remove()` no longer mutates its input** — the previous `append(s[:i], s[i+1:]...)` variant overwrote the caller's backing array.

The rest of that fork's commits target their Plugin Framework migration (null/unknown handling, framework test fixes) and don't apply to this SDKv2 codebase.

## Tests
- New unit tests: `TestValidateSlackToken` (valid/invalid matrix) and `TestRemove_DoesNotMutateInput` (incl. duplicates and missing-value cases).
- `go build`, `go vet`, `golangci-lint run` (0 issues), full `go test ./...` green.