### PR TITLE
feat: detect and reconcile permanent_members drift

### DIFF
--- a/docs/resources/conversation.md
+++ b/docs/resources/conversation.md
@@ -86,7 +86,10 @@ The following arguments are supported:
 - `name` - (Required) name of the public or private channel.
 - `topic` - (Optional) topic for the channel.
 - `purpose` - (Optional) purpose of the channel.
-- `permanent_members` - (Optional) user IDs to add to the channel.
+- `permanent_members` - (Optional) user IDs to add to the channel. Members are
+kept in sync: if a listed user leaves or is removed from the channel, the next
+plan shows the drift and the next apply re-invites them. Users who join the
+channel on their own are not tracked and never produce a diff.
 - `is_private` - (Optional) create a private channel instead of a public one.
 Changing this on an existing channel converts it between public and private
 using the [Slack Admin API](https://api.slack.com/methods/admin.conversations.convertToPrivate),

--- a/slack/data_source_conversation.go
+++ b/slack/data_source_conversation.go
@@ -95,11 +95,5 @@ func dataSourceSlackConversationRead(ctx context.Context, d *schema.ResourceData
 		return diag.FromErr(fmt.Errorf("channel_id or name must be set"))
 	}
 
-	users, _, err := client.GetUsersInConversationContext(ctx, &slack.GetUsersInConversationParameters{
-		ChannelID: channel.ID,
-	})
-	if err != nil {
-		return diag.FromErr(fmt.Errorf("couldn't get users in conversation for %s: %w", channel.ID, err))
-	}
-	return updateChannelData(d, channel, users)
+	return updateChannelData(d, channel)
 }

--- a/slack/resource_conversation.go
+++ b/slack/resource_conversation.go
@@ -251,6 +251,46 @@ func findExistingChannel(ctx context.Context, client *slack.Client, name string,
 	return nil, fmt.Errorf("could not find channel with name %s", name)
 }
 
+// getAllUsersInConversation returns every member of a channel, following
+// cursor pagination and honoring Slack rate-limit responses (a single
+// unpaginated call only returns the first page, which caused false
+// permanent_members drift on channels with more members than one page).
+func getAllUsersInConversation(ctx context.Context, client *slack.Client, channelID string) ([]string, error) {
+	var members []string
+	cursor := ""
+	for {
+		attempt := 0
+		var page []string
+		var nextCursor string
+		var err error
+		for {
+			attempt++
+			page, nextCursor, err = client.GetUsersInConversationContext(ctx, &slack.GetUsersInConversationParameters{
+				ChannelID: channelID,
+				Cursor:    cursor,
+				Limit:     cursorLimit,
+			})
+			if err != nil {
+				if rateLimitedError, ok := err.(*slack.RateLimitedError); ok {
+					time.Sleep(rateLimitedError.RetryAfter)
+				} else {
+					return nil, fmt.Errorf("could not retrieve users in conversation %s: %w", channelID, err)
+				}
+				if attempt > maxRateLimitRetries {
+					return nil, fmt.Errorf("could not retrieve users in conversation after waiting for rate limit: %s: %w", channelID, err)
+				}
+			} else {
+				break
+			}
+		}
+		members = append(members, page...)
+		if nextCursor == "" {
+			return members, nil
+		}
+		cursor = nextCursor
+	}
+}
+
 func updateChannelMembers(ctx context.Context, d *schema.ResourceData, client *slack.Client, channelID string) error {
 	members := d.Get("permanent_members").(*schema.Set)
 
@@ -270,10 +310,7 @@ func updateChannelMembers(ctx context.Context, d *schema.ResourceData, client *s
 	userIDs = remove(userIDs, apiUserInfo.UserID)
 	userIDs = remove(userIDs, channel.Creator)
 
-	channelUsers, _, err := client.GetUsersInConversationContext(ctx, &slack.GetUsersInConversationParameters{
-		ChannelID: channel.ID,
-	})
-
+	channelUsers, err := getAllUsersInConversation(ctx, client, channel.ID)
 	if err != nil {
 		return fmt.Errorf("could not retrieve conversation users for ID %s: %w", channelID, err)
 	}
@@ -357,13 +394,28 @@ func resourceSlackConversationRead(ctx context.Context, d *schema.ResourceData, 
 		}
 	}
 
-	users, _, err := client.GetUsersInConversationContext(ctx, &slack.GetUsersInConversationParameters{
-		ChannelID: channel.ID,
-	})
-	if err != nil {
-		return diag.FromErr(fmt.Errorf("couldn't get users in conversation for %s: %w", channel.ID, err))
+	// permanent_members drift detection: state receives the intersection of
+	// the configured members with the channel's actual members, so members
+	// who left or were removed show up as a diff and get re-invited, while
+	// people who joined organically never produce a false diff.
+	configured := schemaSetToSlice(d.Get("permanent_members").(*schema.Set))
+	if len(configured) > 0 {
+		channelUsers, err := getAllUsersInConversation(ctx, client, channel.ID)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+		present := make([]string, 0, len(configured))
+		for _, member := range configured {
+			if contains(channelUsers, member) {
+				present = append(present, member)
+			}
+		}
+		if err := d.Set("permanent_members", present); err != nil {
+			return diag.Errorf("error setting permanent_members: %s", err)
+		}
 	}
-	return updateChannelData(d, channel, users)
+
+	return updateChannelData(d, channel)
 }
 
 func resourceSlackConversationUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
@@ -483,7 +535,7 @@ func resourceSlackConversationDelete(ctx context.Context, d *schema.ResourceData
 	return diags
 }
 
-func updateChannelData(d *schema.ResourceData, channel *slack.Channel, _ []string) diag.Diagnostics {
+func updateChannelData(d *schema.ResourceData, channel *slack.Channel) diag.Diagnostics {
 	if channel.ID == "" {
 		return diag.Errorf("error setting id: returned channel does not have an id")
 	}

--- a/slack/resource_conversation_read_test.go
+++ b/slack/resource_conversation_read_test.go
@@ -1,0 +1,143 @@
+package slack
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/slack-go/slack"
+)
+
+// newConversationAPIServer mocks conversations.info and a paginated
+// conversations.members endpoint. membersPages are served in order, with a
+// next_cursor pointing to the following page. membersCalls counts how many
+// times conversations.members was hit.
+func newConversationAPIServer(t *testing.T, channelJSON string, membersPages [][]string, membersCalls *int32) *slack.Client {
+	t.Helper()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/conversations.info", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintf(w, `{"ok":true,"channel":%s}`, channelJSON)
+	})
+	mux.HandleFunc("/conversations.members", func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(membersCalls, 1)
+		page := 0
+		if c := r.FormValue("cursor"); c != "" {
+			if _, err := fmt.Sscanf(c, "page-%d", &page); err != nil {
+				t.Errorf("unexpected cursor format %q: %s", c, err)
+			}
+		}
+		next := ""
+		if page < len(membersPages)-1 {
+			next = fmt.Sprintf("page-%d", page+1)
+		}
+		members := "[]"
+		if page < len(membersPages) {
+			members = `["` + membersPages[page][0] + `"`
+			for _, m := range membersPages[page][1:] {
+				members += `,"` + m + `"`
+			}
+			members += "]"
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintf(w, `{"ok":true,"members":%s,"response_metadata":{"next_cursor":"%s"}}`, members, next)
+	})
+
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+
+	return slack.New("xoxp-test", slack.OptionAPIURL(server.URL+"/"))
+}
+
+// TestGetAllUsersInConversation_Paginates ensures every page is fetched; a
+// single unpaginated call only returned the first page, causing false
+// permanent_members drift on large channels.
+func TestGetAllUsersInConversation_Paginates(t *testing.T) {
+	var calls int32
+	client := newConversationAPIServer(t, `{"id":"C123"}`, [][]string{
+		{"U1", "U2"},
+		{"U3"},
+		{"U4"},
+	}, &calls)
+
+	members, err := getAllUsersInConversation(context.Background(), client, "C123")
+	if err != nil {
+		t.Fatalf("expected no error, got: %s", err)
+	}
+
+	want := []string{"U1", "U2", "U3", "U4"}
+	if len(members) != len(want) {
+		t.Fatalf("expected %v, got: %v", want, members)
+	}
+	for i, m := range want {
+		if members[i] != m {
+			t.Errorf("expected member %d to be %s, got %s", i, m, members[i])
+		}
+	}
+	if calls != 3 {
+		t.Errorf("expected 3 paginated calls, got %d", calls)
+	}
+}
+
+// TestConversationRead_PermanentMembersDrift verifies that Read stores the
+// intersection of configured permanent_members with the channel's actual
+// members: a configured member who left shows up as drift (removed from
+// state) while organic members never enter the state.
+func TestConversationRead_PermanentMembersDrift(t *testing.T) {
+	var calls int32
+	// U2 left the channel; U9 joined organically and is not managed.
+	client := newConversationAPIServer(t, `{"id":"C123","name":"test-channel"}`, [][]string{
+		{"U1", "U9"},
+	}, &calls)
+
+	d := schema.TestResourceDataRaw(t, resourceSlackConversation().Schema, map[string]interface{}{
+		"name":              "test-channel",
+		"permanent_members": []interface{}{"U1", "U2"},
+	})
+	d.SetId("C123")
+
+	diags := resourceSlackConversationRead(context.Background(), d, client)
+	if diags.HasError() {
+		t.Fatalf("expected no error, got: %v", diags)
+	}
+
+	got := schemaSetToSlice(d.Get("permanent_members").(*schema.Set))
+	if len(got) != 1 || got[0] != "U1" {
+		t.Errorf("expected permanent_members [U1], got: %v", got)
+	}
+	if calls != 1 {
+		t.Errorf("expected exactly 1 conversations.members call, got %d", calls)
+	}
+}
+
+// TestConversationRead_NoPermanentMembersSkipsMembersCall ensures channels
+// without managed members do not pay the members API call and produce no
+// drift.
+func TestConversationRead_NoPermanentMembersSkipsMembersCall(t *testing.T) {
+	var calls int32
+	client := newConversationAPIServer(t, `{"id":"C123","name":"test-channel"}`, [][]string{
+		{"U1"},
+	}, &calls)
+
+	d := schema.TestResourceDataRaw(t, resourceSlackConversation().Schema, map[string]interface{}{
+		"name": "test-channel",
+	})
+	d.SetId("C123")
+
+	diags := resourceSlackConversationRead(context.Background(), d, client)
+	if diags.HasError() {
+		t.Fatalf("expected no error, got: %v", diags)
+	}
+
+	if calls != 0 {
+		t.Errorf("expected conversations.members not to be called, got %d calls", calls)
+	}
+	if got := schemaSetToSlice(d.Get("permanent_members").(*schema.Set)); len(got) != 0 {
+		t.Errorf("expected empty permanent_members, got: %v", got)
+	}
+}


### PR DESCRIPTION
Brings the behavior of zenchef/terraform-provider-slack@91faf29e (permanent_members tracking) to this SDKv2 codebase, plus the pagination fix it needs to be correct.

## Problem
`permanent_members` never reconciled against reality: `Read` fetched the member list and **discarded it** (`updateChannelData(d, channel, _)`). If a configured member left or was removed from the channel in the Slack UI, the plan showed no diff forever and the user was never re-invited — the 'permanent' contract only held while editing `.tf` files.

## Change
- **Drift detection via intersection**: `Read` now stores configured ∩ actual members. A member who left disappears from state → plan shows the diff → apply re-invites. People who joined the channel organically are not in the configured set, so they never enter state and never cause a false diff.
- **Pagination everywhere**: `conversations.members` was fetched with a single call (first page only, cursor discarded) both in `Read` and in the `action_on_update_permanent_members = \"kick\"` path. On channels larger than one page this would cause false drift and wrong kick decisions. New `getAllUsersInConversation` helper follows cursors with the same rate-limit retry pattern used elsewhere.
- **Fewer API calls**: resources without `permanent_members`, and the `slack_conversation` data source, no longer call `conversations.members` at all (previously always called and thrown away).

## Behavior change
Users listed in `permanent_members` who intentionally left a channel will be re-invited on the next apply. That is the documented intent of the attribute; docs updated to state it explicitly.

## Tests
- `TestGetAllUsersInConversation_Paginates` — 3-page cursor walk, asserts full list and call count.
- `TestConversationRead_PermanentMembersDrift` — configured member who left is dropped from state (drift), organic member is not tracked.
- `TestConversationRead_NoPermanentMembersSkipsMembersCall` — no members configured → zero members API calls.
- `go build`, `go vet`, `golangci-lint run` (0 issues), full `go test ./...` green.